### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Finn-Kraemer/obsidian-objects/security/code-scanning/1](https://github.com/Finn-Kraemer/obsidian-objects/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/lint.yml` at the workflow root (top-level), so it applies to the `lint` job. For this workflow, the minimal and appropriate permission is:

- `contents: read`

This preserves existing functionality (checkout and linting) while documenting and enforcing least privilege. No imports, methods, or additional definitions are needed—just YAML configuration update near the top of the workflow, between `on:` and `jobs:` (or directly after `name:`/`on:` as valid YAML).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
